### PR TITLE
fix for BMP width odd width

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Debug
 Release
 bin
 /*.user
+.vs/

--- a/Helpers/BmpHelper.cs
+++ b/Helpers/BmpHelper.cs
@@ -299,6 +299,18 @@ namespace UnpackMiColorFace.Helpers
             }
             else
             {
+                #region align low width images
+                int newWidth = 0;
+
+                if (type != 4)
+                    data = AlignRowData(data, width, height, type, out newWidth);
+                else
+                    newWidth = width;
+
+                lenRaw = data.Length;
+                width = newWidth;
+                #endregion
+
                 data = FlipImageData(data, width, height, type);
                 data = header.Concat(data).ToArray();
             }

--- a/UnpackMiColorFace.csproj
+++ b/UnpackMiColorFace.csproj
@@ -68,6 +68,11 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="XiaomiWatch.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=51448abaf6d08ec6, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>lib\XiaomiWatch.Common.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Decompiler\DecompilerFactory.cs" />
@@ -96,13 +101,6 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Lib\XiaomiWatch.Common.dll" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\XiaomiWatch.Common\XiaomiWatch.Common.csproj">
-      <Project>{8715a0b0-e2c0-4a22-bf44-2992efb274af}</Project>
-      <Name>XiaomiWatch.Common</Name>
-      <Private>False</Private>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.7.2">

--- a/UnpackMiColorFace.sln
+++ b/UnpackMiColorFace.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34202.233
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnpackMiColorFace", "UnpackMiColorFace.csproj", "{E1CD874F-2661-46E5-B04D-193B13BD4BDE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E1CD874F-2661-46E5-B04D-193B13BD4BDE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1CD874F-2661-46E5-B04D-193B13BD4BDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1CD874F-2661-46E5-B04D-193B13BD4BDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1CD874F-2661-46E5-B04D-193B13BD4BDE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8B6A35E7-8CB0-436C-AD4D-FB7E7CD93585}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
The example of the watchface causing the issue: [Chine.zip](https://github.com/m0tral/UnpackMiColorFace/files/14553800/Chine.zip)
The image_0000 has 197 pixels width. It produces the following .bmp file: [img_0000_2_.zip](https://github.com/m0tral/UnpackMiColorFace/files/14553808/img_0000_2_.zip)
This image can be opened in Photoshop, but it looks this way: 
![img_0000_2_](https://github.com/m0tral/UnpackMiColorFace/assets/5512376/cf235013-9d90-405e-a662-b825f56896c2)
This patch aligns width to 2 and the result looks right: [img_0000_2_0-fix.zip](https://github.com/m0tral/UnpackMiColorFace/files/14553840/img_0000_2_0-fix.zip)
